### PR TITLE
[IC-73] Update Finish personal number validator

### DIFF
--- a/src/PersonalNumber/Finnish.elm
+++ b/src/PersonalNumber/Finnish.elm
@@ -64,6 +64,18 @@ checksumChars =
     "0123456789ABCDEFHJKLMNPRSTUVWXY"
 
 
+{-| Separators used in personal identity codes:
+
+  - for those born in or after 2000, letters A, B, C, D, E, F.
+  - for those born in the 1900s, the current hyphen (-) or the letters Y, X, W, V, U.
+  - for those born in the 19th century, a plus sign (+).
+
+-}
+separatorChars : String
+separatorChars =
+    "-+ABCDEFYXWVU"
+
+
 personalNumberParser : Parser PersonalNumber
 personalNumberParser =
     (getChompedString <|
@@ -75,7 +87,7 @@ personalNumberParser =
             |. digit
             |. digit
             |. digit
-            |. chompIf (\c -> c == '-' || c == '+' || c == 'A')
+            |. chompIf (String.fromChar >> flip String.contains separatorChars)
             |. digit
             |. digit
             |. digit

--- a/tests/FinnishTest.elm
+++ b/tests/FinnishTest.elm
@@ -32,6 +32,21 @@ suite =
                     PersonalNumber.fromString "010200A9618"
                         |> Result.map PersonalNumber.display
                         |> Expect.equal (Ok "010200A9618")
+            , test "should accept a PNR with a different century marker for those born in or after 2000" <|
+                \_ ->
+                    PersonalNumber.fromString "010200F9618"
+                        |> Result.map PersonalNumber.display
+                        |> Expect.equal (Ok "010200F9618")
+            , test "should accept a PNR with a different century marker for those born in the 1900s" <|
+                \_ ->
+                    PersonalNumber.fromString "010200X9618"
+                        |> Result.map PersonalNumber.display
+                        |> Expect.equal (Ok "010200X9618")
+            , test "should accept a PNR with a different century marker for those born in the 19th century" <|
+                \_ ->
+                    PersonalNumber.fromString "010200+9618"
+                        |> Result.map PersonalNumber.display
+                        |> Expect.equal (Ok "010200+9618")
             , test "should not accept a PNR with an invalid checksum" <|
                 \_ -> Expect.err (PersonalNumber.fromString "131052308X")
             , test "should not accept an empty value" <|


### PR DESCRIPTION
Taken from https://dvv.fi/en/reform-of-personal-identity-code:

```
Separators used in personal identity codes: 

for those born in or after 2000, letters A, B, C, D, E, F.
for those born in the 1900s, the current hyphen (-) or the letters Y, X, W, V, U.
for those born in the 19th century, a plus sign (+). 
```