### PR TITLE
[FU-139] Allow dashes in NoBankID Personal Numbers

### DIFF
--- a/src/PersonalNumber/Norwegian.elm
+++ b/src/PersonalNumber/Norwegian.elm
@@ -147,7 +147,7 @@ fromString : String -> Result ValidationError PersonalNumber
 fromString str =
     let
         pnr =
-            String.trim str
+            String.filter (\c -> List.notMember c [ '-', ' ' ]) <| String.trim str
     in
     case String.length pnr of
         11 ->

--- a/tests/NorwegianTest.elm
+++ b/tests/NorwegianTest.elm
@@ -29,6 +29,11 @@ suite =
                     fromString "  19118438739  "
                         |> Result.map PersonalNumber.toString
                         |> Expect.equal (Ok "19118438739")
+            , test "should accept a PNR with dashes" <|
+                \_ ->
+                    fromString "191184-387-39"
+                        |> Result.map PersonalNumber.toString
+                        |> Expect.equal (Ok "19118438739")
             , test "should not accept a PNR without the last four digits" <|
                 \_ -> Expect.err (fromString "200866001386")
             , test "should not accept a PNR with alpha characters not in checknum position" <|


### PR DESCRIPTION
Personal number parsing should (IMO) accept dashes.

This makes parsing play nicer with the `display` function, which produces dashes for readability.