### PR TITLE
Simplify danish company number

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ A library for validating personal numbers. Built from the ground up using parser
 - Norwegian personal numbers (fødselsnummer).
 - Finnish personal numbers (henkilötunnus).
 - Danish personal numbers (personnummer).
+- Danish company numbers (CVR-nummer).
 
 ## Example usage
 


### PR DESCRIPTION
I noticed Journey used a simpler code to validate the Company Numbers, so I copied it over here. I think it's better than the parser, which is used just to validate everything is digits.

There should be no semantic changes, tests pass.